### PR TITLE
[OAuth] Change the default token endpoint url

### DIFF
--- a/basic/application-oauth.properties
+++ b/basic/application-oauth.properties
@@ -24,7 +24,7 @@ camel.component.kafka.sasl-mechanism = OAUTHBEARER
 camel.component.kafka.sasl-jaas-config = org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
         oauth.client.id='<YOUR-SERVICE-ACCOUNT-ID-HERE>' \
         oauth.client.secret='<YOUR-SERVICE-ACCOUNT-SECRET-HERE>' \
-        oauth.token.endpoint.uri="https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token" ;
+        oauth.token.endpoint.uri="https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token" ;
 camel.component.kafka.additional-properties[sasl.login.callback.handler.class] = io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
 
 consumer.topic=test


### PR DESCRIPTION
The token endpoint URL is being changed to a new value and newly provisioned clusters already use the new value

see https://issues.redhat.com/browse/MGDSRVS-188